### PR TITLE
Fix Profile candidate check and avoid stdlib shadowing

### DIFF
--- a/igv_types/profile_candidate.py
+++ b/igv_types/profile_candidate.py
@@ -1,4 +1,7 @@
 
+from db import ops
+
+
 class Profile:
     def __init__(self, username, user_id, source_account, 
                  followers, following, posts_count,
@@ -19,7 +22,7 @@ class Profile:
 
     @username.setter
     def username(self, value):
-        if value in ops.get_profile(value):
+        if ops.get_profile(value):
             raise ValueError(f"Username '{value}' is already in the database")
         self._username = value
 

--- a/utils/profile_scraper.py
+++ b/utils/profile_scraper.py
@@ -1,13 +1,14 @@
 from login import account_login
 from instagrapi import Client
 from db import ops
-from types.profile_candidate import Profile
+from igv_types.profile_candidate import Profile
 
 #Function: get list of followers of source account
 def get_source_account_followers(cl: Client, source_account: str, amount: int) -> list:
+    pass
 #Function: filter out unfitting profiles
 def is_valid_profile(account: Client) -> bool:
-    ...
+    pass
     #check basic needs - create file which stores these needs in one place
     #use is_in_database function here too
     
@@ -68,7 +69,7 @@ def concatanate_profile_data(account, source_account) -> dict:
     }
 
 def store_profile_data() -> None:
-    ...
+    pass
     #store in database. add time delays.
 '''
 


### PR DESCRIPTION
## Summary
- rename local `types` package to `igv_types` to prevent shadowing the stdlib
- update imports in scraper code accordingly
- add missing database import and username existence check
- stub out empty functions so code compiles

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688689e0267483308c38142abff2b8ce